### PR TITLE
build for armv6, modernize release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,11 @@ on:
 # Don't forget to tag back to @main before merge.
 
 jobs:
-  # test:
-  #   uses: ./.github/workflows/test.yml
+  test:
+    uses: ./.github/workflows/test.yml
 
   publish:
-    # needs: test
+    needs: test
     strategy:
       matrix:
         include:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,5 @@
 name: Build and Publish
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-
 on:
   push:
     tags:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,3 +52,4 @@ jobs:
         version: ${{ github.event_name == 'push' && github.ref_name || '""' }}
         key-id: ${{ secrets.VIAM_DEV_API_KEY_ID }}
         key-value: ${{ secrets.VIAM_DEV_API_KEY }}
+        do-upload: ${{ github.event_name == 'push' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build and Publish RC
+name: Build and Publish
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,17 +23,17 @@ jobs:
       matrix:
         include:
           - arch: buildjet-8vcpu-ubuntu-2204
-            image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
             platform: linux/amd64
-            label: amd64
+            goarch: amd64
           - arch: buildjet-8vcpu-ubuntu-2204-arm
-            image: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
             platform: linux/arm64
-            label: arm64
+            goarch: arm64
+          - arch: buildjet-8vcpu-ubuntu-2204-arm
+            platform: linux/arm32v6
+            goarch: arm
+            goarm: '6'
 
     runs-on: ${{ matrix.arch }}
-    container:
-      image: ${{ matrix.image }}
 
     steps:
     - uses: actions/checkout@v3
@@ -41,11 +41,10 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.23
+        go-version-file: go.mod
 
     - name: Build module
-      run: |
-        sudo -u testbot bash -lc 'make module'
+      run: GOARCH=${{ matrix.goarch }} GOARM=${{ matrix.goarm }} make module
 
     - name: Upload sensirion module to registry
       uses: viamrobotics/upload-module@main
@@ -53,6 +52,6 @@ jobs:
         meta-path: meta.json
         module-path: bin/module.tar.gz
         platform: ${{ matrix.platform }}
-        version: ${{ github.ref_name }}
+        version: ${{ github.event_name == 'push' && github.ref_name || '' }}
         key-id: ${{ secrets.VIAM_DEV_API_KEY_ID }}
         key-value: ${{ secrets.VIAM_DEV_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,10 @@ jobs:
     runs-on: ${{ matrix.arch }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v6
       with:
         go-version-file: go.mod
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,11 @@ on:
 # Don't forget to tag back to @main before merge.
 
 jobs:
-  test:
-    uses: ./.github/workflows/test.yml
+  # test:
+  #   uses: ./.github/workflows/test.yml
 
   publish:
-    needs: test
+    # needs: test
     strategy:
       matrix:
         include:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,6 @@ jobs:
         meta-path: meta.json
         module-path: bin/module.tar.gz
         platform: ${{ matrix.platform }}
-        version: ${{ github.event_name == 'push' && github.ref_name || '' }}
+        version: ${{ github.event_name == 'push' && github.ref_name || '""' }}
         key-id: ${{ secrets.VIAM_DEV_API_KEY_ID }}
         key-value: ${{ secrets.VIAM_DEV_API_KEY }}


### PR DESCRIPTION
## What changed
- main change: add armv6 platform to release.yml
- build without rdk-devenv container (the base image is large and this saves time)
- bump versions for actions/checkout and setup-go
- do a no-upload run when triggered manually with `workflow_dispatch` so that this is testable
## Why
Support a 32-bit arm device. (Other changes incidental).
## Sample build
https://github.com/viam-modules/sensirion/actions/runs/18324393009

(I have one more running with tests uncommented https://github.com/viam-modules/sensirion/actions/runs/18324519192).